### PR TITLE
use server thin for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 
 group :development, :test do
   gem 'capistrano', '2.9.0', :require => false
+  gem 'thin'
 end
 # for the "no javascript runtime error" upgrading to 3.1
 gem 'execjs'


### PR DESCRIPTION
Firstly add the line below to Gemfile:    `gem 'thin'`

then, install thin:     `bundle install`

lastly launch the server thin, which is the default server for rails app:    `rails s`

more info to link:

http://stackoverflow.com/questions/1156759/webrick-is-very-slow-to-respond-how-to-speed-it-up
